### PR TITLE
Add mobile reading guide, improve mobile layout and accessibility, prefer reflections in previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,6 +157,7 @@ function renderGrid(quotes) {
     }
 
     container.innerHTML = '';
+    renderMobileGuide(container);
 
     const header = document.createElement('div');
     header.className = 'results-header';
@@ -185,7 +186,7 @@ function renderGrid(quotes) {
                     <div class="q-card-author">${q.author} <span class="q-card-contrib">via ${q.contributor}</span></div>
                     <div class="q-card-dept">${q.department}</div>
                 </div>
-                <div class="q-card-arrow">→</div>
+                <div class="q-card-arrow" aria-hidden="true">Read</div>
             </div>
         `;
         card.addEventListener('click', () => openDeck(quotes, i));
@@ -196,6 +197,23 @@ function renderGrid(quotes) {
     });
 
     container.appendChild(grid);
+}
+
+function renderMobileGuide(container) {
+    const guide = document.createElement('section');
+    guide.className = 'mobile-reading-guide';
+    guide.setAttribute('aria-label', 'How to use this archive');
+    guide.innerHTML = `
+        <div class="mobile-guide-kicker">Start here</div>
+        <h2 class="mobile-guide-title">Read one. Then swipe for the next.</h2>
+        <p class="mobile-guide-copy">Tap any card to open the reflection, swipe left or right between quotes, and leave a comment in the discussion.</p>
+        <div class="mobile-guide-steps">
+            <span>1 Tap a card</span>
+            <span>2 Swipe</span>
+            <span>3 Comment</span>
+        </div>
+    `;
+    container.appendChild(guide);
 }
 
 /* ─── SEARCH ─── */
@@ -285,6 +303,7 @@ function accentForName(name) {
 function renderContributors() {
     const container = document.getElementById('mainContent');
     container.innerHTML = '';
+    renderMobileGuide(container);
 
     // Build contributor index
     const index = {};
@@ -314,8 +333,8 @@ function renderContributors() {
             <div class="hof-rule"></div>
             <div class="hof-title-wrap">
                 <div class="hof-eyebrow">English Department</div>
-                <div class="hof-title">Hall of Fame</div>
-                <div class="hof-sub">Our most prolific voices</div>
+                <div class="hof-title">Voices in the Archive</div>
+                <div class="hof-sub">The people behind the reflections</div>
             </div>
             <div class="hof-rule"></div>
         </div>
@@ -345,8 +364,8 @@ function renderContributors() {
                 <span class="hof-count-num">${c.quotes.length}</span>
                 <span class="hof-count-label">${c.quotes.length === 1 ? 'quote' : 'quotes'}</span>
             </div>
-            <div class="hof-preview">"${latestQuote.quote.length > 80 ? latestQuote.quote.slice(0, 77) + '…' : latestQuote.quote}"</div>
-            <button class="hof-view-btn" aria-label="View ${c.name}'s quotes">View all →</button>
+            <div class="hof-preview">"${latestQuote.about ? (latestQuote.about.length > 80 ? latestQuote.about.slice(0, 77) + '…' : latestQuote.about) : latestQuote.quote.length > 80 ? latestQuote.quote.slice(0, 77) + '…' : latestQuote.quote}"</div>
+            <button class="hof-view-btn" aria-label="Read ${c.name}'s reflections">Read reflections →</button>
         `;
         card.querySelector('.hof-view-btn').addEventListener('click', () => {
             renderGrid(c.quotes);
@@ -394,7 +413,7 @@ function renderContributors() {
                     </div>
                     <div class="contrib-badge">${c.quotes.length}</div>
                 </div>
-                <div class="contrib-preview">"${latest.quote.length > 100 ? latest.quote.slice(0, 97) + '…' : latest.quote}"</div>
+                <div class="contrib-preview">"${latest.about ? (latest.about.length > 100 ? latest.about.slice(0, 97) + '…' : latest.about) : latest.quote.length > 100 ? latest.quote.slice(0, 97) + '…' : latest.quote}"</div>
                 <div class="contrib-footer">
                     <span class="contrib-author-tag">— ${latest.author}</span>
                     <span class="contrib-arrow">→</span>
@@ -418,6 +437,7 @@ function renderContributors() {
 function renderGroupedGrid(groupBy) {
     const container = document.getElementById('mainContent');
     container.innerHTML = '';
+    renderMobileGuide(container);
 
     const index = {};
     DB.forEach(item => {
@@ -465,7 +485,7 @@ function renderGroupedGrid(groupBy) {
                         <div class="q-card-author">${q.author} <span class="q-card-contrib">via ${q.contributor}</span></div>
                         <div class="q-card-dept">${q.department}</div>
                     </div>
-                    <div class="q-card-arrow">→</div>
+                    <div class="q-card-arrow" aria-hidden="true">Read</div>
                 </div>
             `;
             card.addEventListener('click', () => openDeck(groupQuotes, i));
@@ -574,6 +594,7 @@ function openDeck(quotes, startIdx) {
                 </div>
                 <div class="deck-right">
                     <div class="deck-comments-label">Discussion</div>
+                    <div class="deck-comment-prompt">What did this quote make you think about? Add a short response for the contributor.</div>
                     <div class="giscus-mount" id="giscus-slot-${i}"></div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -259,6 +259,8 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 }
 
+.mobile-reading-guide { display: none; }
+
 /* QUOTE CARD */
 .q-card {
     background: var(--surface);
@@ -319,11 +321,17 @@ body {
 .q-card-dept { font-family: var(--mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ink-ghost); }
 
 .q-card-arrow {
-    width: 28px; height: 28px;
-    border-radius: 50%;
+    min-width: 54px;
+    min-height: 30px;
+    padding: 0 12px;
+    border-radius: 999px;
     border: 1px solid var(--gold-border);
     display: flex; align-items: center; justify-content: center;
-    font-size: 12px; color: var(--gold);
+    font-family: var(--mono);
+    font-size: 8px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--gold);
     flex-shrink: 0;
     transition: all 0.25s var(--spring);
 }
@@ -761,6 +769,19 @@ body {
     border-bottom: 1px solid rgba(255,255,255,0.07);
 }
 
+.deck-comment-prompt {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 1rem;
+    line-height: 1.45;
+    color: rgba(255,255,255,0.72);
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+}
+
 /* ─── 8. DECK CARD ─── */
 .deck-card {
     background: var(--surface);
@@ -899,9 +920,39 @@ body {
 /* ─── 10. MOBILE ─── */
 @media (max-width: 767px) {
 
-    .masthead-inner { padding: 16px 16px 10px; }
+    .masthead {
+        background: rgba(248, 245, 239, 0.96);
+    }
+
+    .masthead-inner { padding: 18px 16px 12px; }
     .masthead-meta { flex-direction: column; gap: 8px; }
-    .meta-pill { min-width: 0; }
+    .masthead-title { font-size: clamp(38px, 13vw, 54px); }
+    .masthead-subtitle { font-size: 8px; letter-spacing: 2.2px; }
+    .meta-pill { min-width: 0; padding: 4px 12px; }
+    .masthead-meta .meta-pill:first-child { display: none; }
+    .nav-bar {
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        padding: 10px 14px 14px;
+        gap: 8px;
+        scroll-padding-left: 14px;
+    }
+    .quick-tab {
+        min-height: 42px;
+        padding: 10px 16px;
+        font-size: 9px;
+        letter-spacing: 1.4px;
+    }
+    .search-wrap {
+        flex: 0 0 210px;
+        margin-left: 2px;
+    }
+    .search-input,
+    .search-input:focus {
+        width: 100%;
+        min-height: 42px;
+        font-size: 12px;
+    }
 
     /* Compact masthead */
     .masthead--compact .top-rule,
@@ -930,9 +981,9 @@ body {
     .masthead-compact-actions { display: flex; gap: 8px; }
 
     .compact-icon-btn {
-        width: 34px; height: 34px;
+        width: 42px; height: 42px;
         border: 1px solid var(--gold-border);
-        border-radius: 8px;
+        border-radius: 14px;
         background: var(--gold-pale);
         cursor: pointer;
         display: flex; align-items: center; justify-content: center;
@@ -942,11 +993,11 @@ body {
     }
     .compact-icon-btn:hover { background: var(--gold); color: white; border-color: var(--gold); }
 
-    .compact-search-bar { display: none; padding: 0 16px 10px; }
+    .compact-search-bar { display: none; padding: 0 16px 12px; }
     .compact-search-bar.open { display: block; }
     .compact-search-bar input {
         width: 100%; box-sizing: border-box;
-        padding: 8px 14px;
+        padding: 12px 14px;
         border: 1px solid var(--gold-border);
         border-radius: 30px;
         font-family: var(--sans); font-size: 11px; letter-spacing: 0.5px;
@@ -982,7 +1033,7 @@ body {
     .filter-sheet-title { font-family: var(--mono); font-size: 9px; letter-spacing: 3px; text-transform: uppercase; color: var(--ink-muted); margin-bottom: 14px; }
     .filter-sheet-tabs { display: flex; flex-direction: column; gap: 6px; }
     .filter-sheet-tab {
-        width: 100%; padding: 14px 18px;
+        width: 100%; padding: 16px 18px;
         text-align: left;
         border: 1px solid var(--gold-border); border-radius: 12px;
         background: transparent;
@@ -994,9 +1045,77 @@ body {
     .filter-sheet-tab.active { background: var(--gold); border-color: var(--gold); color: white; font-weight: 500; }
 
     /* Grid */
-    .newspaper-body { padding: 24px 12px 80px; }
-    .col-grid { grid-template-columns: 1fr; gap: 12px; }
-    .q-card { padding: 20px 16px 16px; gap: 14px; }
+    .newspaper-body { padding: 18px 12px 88px; }
+    .mobile-reading-guide {
+        display: block;
+        background: linear-gradient(135deg, rgba(184,145,58,0.16), rgba(255,255,255,0.72));
+        border: 1px solid var(--gold-border);
+        border-radius: 24px;
+        padding: 20px 18px;
+        margin-bottom: 18px;
+        box-shadow: var(--sh-sm);
+    }
+    .mobile-guide-kicker {
+        font-family: var(--mono);
+        font-size: 8px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        color: var(--gold);
+        margin-bottom: 8px;
+    }
+    .mobile-guide-title {
+        font-family: var(--fell);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 1.85rem;
+        line-height: 1;
+        color: var(--ink);
+        margin-bottom: 10px;
+    }
+    .mobile-guide-copy {
+        font-family: var(--sans);
+        font-size: 0.98rem;
+        line-height: 1.48;
+        color: var(--ink-mid);
+        margin-bottom: 14px;
+    }
+    .mobile-guide-steps {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+    }
+    .mobile-guide-steps span {
+        min-height: 42px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        border-radius: 999px;
+        background: var(--surface);
+        border: 1px solid var(--gold-border);
+        font-family: var(--mono);
+        font-size: 8px;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        color: var(--ink-muted);
+    }
+    .results-header { margin-bottom: 16px; }
+    .col-grid { grid-template-columns: 1fr; gap: 14px; }
+    .q-card {
+        padding: 22px 18px 18px;
+        gap: 16px;
+        border-radius: 22px;
+        min-height: 210px;
+    }
+    .q-card::before { font-size: 96px; right: 14px; }
+    .q-card-text { font-size: 1.42rem; line-height: 1.42; }
+    .q-card-reflection { font-size: 0.9rem; line-height: 1.55; }
+    .q-card-footer { align-items: flex-end; }
+    .q-card-arrow {
+        min-width: 66px;
+        min-height: 38px;
+        font-size: 8px;
+    }
 
     /* Hall of Fame on mobile — stack vertically */
     .hof-podium {
@@ -1015,15 +1134,16 @@ body {
     .contrib-grid { grid-template-columns: 1fr; gap: 10px; }
 
     /* Deck */
-    .deck-slide { padding-top: 64px; overflow-y: auto; }
+    .deck-topbar { padding: 14px 14px 10px; position: sticky; background: rgba(8, 7, 5, 0.88); backdrop-filter: blur(16px); }
+    .deck-slide { padding-top: 8px; overflow-y: auto; }
     .deck-layout { flex-direction: column; min-height: unset; }
-    .deck-left { width: 100%; padding: 12px 12px 4px; border-right: none; border-bottom: 1px solid rgba(255,255,255,0.07); overflow-y: visible; }
-    .deck-right { width: 100%; padding: 16px 12px 24px; background: rgba(0,0,0,0.18); }
+    .deck-left { width: 100%; padding: 12px 10px 4px; border-right: none; border-bottom: 1px solid rgba(255,255,255,0.07); overflow-y: visible; }
+    .deck-right { width: 100%; padding: 18px 12px 32px; background: rgba(0,0,0,0.18); }
     .deck-card { border-radius: 18px; }
-    .dc-body { padding: 20px 18px 14px; }
+    .dc-body { padding: 24px 20px 14px; }
     .dc-kicker { font-size: 8px; letter-spacing: 3px; margin-bottom: 16px; }
-    .dc-quote { font-size: 18px; line-height: 1.4; padding-left: 14px; border-left-width: 3px; margin-bottom: 18px; }
-    .dc-author { font-size: 20px; }
+    .dc-quote { font-size: clamp(24px, 7vw, 32px); line-height: 1.32; padding-left: 16px; border-left-width: 3px; margin-bottom: 22px; }
+    .dc-author { font-size: 23px; }
     .dc-role { font-size: 9px; margin-top: 3px; }
     .dc-byline { margin-bottom: 18px; }
     .dc-envelope { padding: 16px; border-radius: 12px; margin-bottom: 16px; }
@@ -1031,9 +1151,10 @@ body {
     .dc-contrib-name { font-size: 18px; }
     .dc-contrib-dept { font-size: 8px; margin-top: 2px; }
     .dc-divider { margin: 12px 0; }
-    .dc-reflection { font-size: 13px; line-height: 1.6; }
+    .dc-reflection { font-size: 15px; line-height: 1.65; }
     .deck-action-row { padding: 0 18px 18px; gap: 8px; flex-direction: row; }
-    .btn-premium-action { padding: 10px 14px; font-size: 10px; min-width: 0; }
+    .btn-premium-action { padding: 13px 14px; font-size: 10px; min-width: 0; min-height: 44px; }
+    .deck-comment-prompt { font-size: 1.08rem; }
     .deck-nav-arrows { display: none; }
     .search-input { width: 130px; }
     .search-input:focus { width: 160px; }


### PR DESCRIPTION
### Motivation
- Introduce a small onboarding cue for mobile users to explain how to read and interact with quotes. 
- Improve mobile layout, touch targets and visual hierarchy to make the archive more approachable on small screens. 
- Surface contributors' reflections when available in previews and make several UI/label tweaks for clarity and accessibility.

### Description
- Add a new `renderMobileGuide` function and inject a `mobile-reading-guide` section at the top of `renderGrid`, `renderContributors`, and `renderGroupedGrid` so mobile users see a short how-to card. 
- Prefer `about`/reflection text over the raw `quote` for contributor previews in the Hall of Fame and contributor grid and update the corresponding button labels to emphasize "Read reflections".
- Replace the arrow glyph in `.q-card-arrow` with an accessible pill that reads `Read`, add `aria-hidden="true"` and expand its CSS to a larger, tappable pill; update various mobile CSS rules to improve spacing, typography, masthead, search and deck layouts. 
- Add a `deck-comment-prompt` paragraph inside the deck right column and minor deck/topbar tweaks for improved mobile presentation.

### Testing
- No automated tests were executed as part of this change and no test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc423c9e08332ba40638a76c0f0bc)